### PR TITLE
Remove the clone folder before cloning.

### DIFF
--- a/src/runClusterTests.sh
+++ b/src/runClusterTests.sh
@@ -21,12 +21,13 @@ SDN_DIR=$WORK_DIR/spring-data-neo4j
 
 mkdir -p $WORK_DIR
 
-if [[ ! -d "$SDN_DIR" ]]
+if [[ -d $SDN_DIR ]]
 then
-  git clone --depth 1 --branch $SDN_VERSION https://github.com/spring-projects/spring-data-neo4j.git $SDN_DIR
-else
-  echo "$SDN_DIR already exists, not checking out project."
+  echo "Removing existing clone at $SDN_DIR"
+  rm -rf $SDN_DIR
 fi
+
+git clone --depth 1 --branch $SDN_VERSION https://github.com/spring-projects/spring-data-neo4j.git $SDN_DIR
 
 (
   cd $SDN_DIR


### PR DESCRIPTION
This ensures that we always create a clean clone and not accidentally run against a wrong tag/branch/revision.
Right now `SDN_DIR=$WORK_DIR/spring-data-neo4j` ensures that there is at least `/spring-data-neo4j` as content in the directory variable.
If this should get changed, we should check that `SDN_DIR` is not empty and not `/` :D 